### PR TITLE
Fix typo in page heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,6 @@
   </head>
 
   <body>
-    <h1 class="some-heading">GIT WORKFLOW WORKSHOW</h1>
+    <h1 class="some-heading">GIT WORKFLOW WORKSHOP</h1>
   </body>
 </html>


### PR DESCRIPTION
Fixes the typo in the page heading. "WORKSHOW" corrected to "WORKSHOP"

Relates #3